### PR TITLE
feat(cli): Add saga os and apply some refactoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@ docs/dist
 dist
 temp
 .DS_Store
-
+.idea/

--- a/cmd/playground/buildEvmos.go
+++ b/cmd/playground/buildEvmos.go
@@ -8,7 +8,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const LocalVesrsion = "local"
+const LocalVersion = "local"
 
 // buildEvmosCmd represents the buildEvmos command
 var buildEvmosCmd = &cobra.Command{
@@ -27,7 +27,7 @@ var buildEvmosCmd = &cobra.Command{
 		path, err := cmd.Flags().GetString("path")
 		// Local build
 		if err == nil && path != "" {
-			version := LocalVesrsion
+			version := LocalVersion
 			if path[len(path)-1] == '/' {
 				path = path[0 : len(path)-2]
 			}

--- a/cmd/playground/build_saga_os.go
+++ b/cmd/playground/build_saga_os.go
@@ -1,0 +1,85 @@
+package playground
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/hanchon/hanchond/playground/filesmanager"
+	"github.com/spf13/cobra"
+)
+
+// buildSagaOSCmd represents the buildSagaOSCmd command
+var buildSagaOSCmd = &cobra.Command{
+	Use:   "build-sagaos",
+	Short: "Build an specific version of sagaosd (hanchond playground build-sagaos v0.8.0), it also supports local repositories (hanchond playground build-sagaos --path $HOME/sagaxyz/sagaos)",
+	Long:  `It downloads, builds and clean up temp files for any SagaOS tag. Using the --path flag will build you local repo`,
+	Run: func(cmd *cobra.Command, args []string) {
+		_ = filesmanager.SetHomeFolderFromCobraFlags(cmd)
+
+		// Create build folder if needed
+		if err := filesmanager.CreateBuildsDir(); err != nil {
+			fmt.Println("could not create build folder:" + err.Error())
+			os.Exit(1)
+		}
+
+		// TODO: refactor this to not have to manually replicate this cleanup logic etc. for every build
+		// we should rather create an interface ChainBinaryInfo or smth. that serves unified Build() and Get... functions instead
+		// and then force the implementation for every built binary.
+		path, err := cmd.Flags().GetString("path")
+		// Local build
+		if err == nil && path != "" {
+			version := LocalVersion
+			path = strings.TrimRight(path, "/")
+
+			fmt.Println("Building sagaos...")
+			if err := filesmanager.BuildEvmos(path); err != nil {
+				fmt.Println("error building sagaos:", err.Error())
+				os.Exit(1)
+			}
+			fmt.Println("Moving built binary...")
+			if err := filesmanager.MoveFile(path+"/build/sagaosd", filesmanager.GetSagaosdPath(version)); err != nil {
+				fmt.Println("could not move the built binary:", err.Error())
+				os.Exit(1)
+			}
+			os.Exit(0)
+		}
+
+		// Clone from github
+		if len(args) == 0 {
+			fmt.Println("version is missing. Usage: hanchond playground build-sagaosd v0.8.0")
+			os.Exit(1)
+		}
+		version := args[0]
+		if err := filesmanager.CreateTempFolder(version); err != nil {
+			fmt.Println("could not create temp folder:" + err.Error())
+			os.Exit(1)
+		}
+		fmt.Println("Cloning sagaos version:", version)
+		if err := filesmanager.GitCloneSagaOSBranch(version); err != nil {
+			fmt.Println("could not clone the sagaos version: ", err)
+			os.Exit(1)
+		}
+		fmt.Println("Building sagaos...")
+		if err := filesmanager.BuildEvmosVersion(version); err != nil {
+			fmt.Println("error building sagaos:", err)
+			os.Exit(1)
+		}
+		fmt.Println("Moving built binary...")
+		if err := filesmanager.SaveSagaOSBuiltVersion(version); err != nil {
+			fmt.Println("could not move the built binary:", err.Error())
+			os.Exit(1)
+		}
+		fmt.Println("Cleaning up...")
+		if err := filesmanager.CleanUpTempFolder(); err != nil {
+			fmt.Println("could not remove temp folder", err.Error())
+			os.Exit(1)
+		}
+		os.Exit(0)
+	},
+}
+
+func init() {
+	PlaygroundCmd.AddCommand(buildSagaOSCmd)
+	buildSagaOSCmd.Flags().StringP("path", "p", "", "Path to you local clone of Evmos")
+}

--- a/cmd/playground/initChain.go
+++ b/cmd/playground/initChain.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hanchon/hanchond/playground/evmos"
 	"github.com/hanchon/hanchond/playground/filesmanager"
 	"github.com/hanchon/hanchond/playground/gaia"
+	"github.com/hanchon/hanchond/playground/sagaos"
 	"github.com/hanchon/hanchond/playground/sql"
 
 	"github.com/spf13/cobra"
@@ -94,6 +95,27 @@ var initChainCmd = &cobra.Command{
 					chainID,
 					fmt.Sprintf("validator-key-%d-%d", chainNumber, k),
 					"icsstake",
+				).Daemon
+			}
+		case "sagaos":
+			if chainID == "" {
+				chainID = fmt.Sprintf("sagaos_1234-%d", chainNumber)
+			}
+
+			for k := range nodes {
+				if filesmanager.IsNodeHomeFolderInitialized(int64(chainNumber), int64(k)) {
+					fmt.Printf("the home folder already exists: %d-%d\n", chainNumber, k)
+					os.Exit(1)
+				}
+
+				path := filesmanager.GetNodeHomeFolder(int64(chainNumber), int64(k))
+				nodes[k] = sagaos.NewSagaOS(
+					fmt.Sprintf("moniker-%d-%d", chainNumber, k),
+					version,
+					path,
+					chainID,
+					fmt.Sprintf("validator-key-%d-%d", chainNumber, k),
+					"psaga",
 				).Daemon
 			}
 		default:

--- a/cmd/playground/removeData.go
+++ b/cmd/playground/removeData.go
@@ -21,7 +21,7 @@ var removeDataCmd = &cobra.Command{
 		queries := sql.InitDBFromCmd(cmd)
 
 		// Stop all nodes
-		fmt.Println("Stoping all the running nodes...")
+		fmt.Println("Stopping all the running nodes...")
 		stopping := false
 		if nodes, err := queries.GetAllNodes(context.Background()); err == nil {
 			// Database is initialized
@@ -38,7 +38,7 @@ var removeDataCmd = &cobra.Command{
 		}
 
 		// Stop the relayer
-		fmt.Println("Stoping the relayer...")
+		fmt.Println("Stopping the relayer...")
 		if relayer, err := queries.GetRelayer(context.Background()); err == nil {
 			// The relayer is runnning
 			if relayer.IsRunning == 1 {

--- a/cmd/playground/startChain.go
+++ b/cmd/playground/startChain.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hanchon/hanchond/playground/database"
 	"github.com/hanchon/hanchond/playground/evmos"
 	"github.com/hanchon/hanchond/playground/gaia"
+	"github.com/hanchon/hanchond/playground/sagaos"
 	"github.com/hanchon/hanchond/playground/sql"
 	"github.com/spf13/cobra"
 )
@@ -45,8 +46,11 @@ var startChainCmd = &cobra.Command{
 			case strings.Contains(version, "evmos"):
 				d := evmos.NewEvmos(v.Moniker, v.BinaryVersion, v.ConfigFolder, v.ChainID_2, v.ValidatorKeyName, v.Denom)
 				pID, err = d.Start()
+			case strings.Contains(version, "sagaos"):
+				d := sagaos.NewSagaOS(v.Moniker, v.BinaryVersion, v.ConfigFolder, v.ChainID_2, v.ValidatorKeyName, v.Denom)
+				pID, err = d.Start()
 			default:
-				fmt.Println("incorrect binary name")
+				fmt.Printf("binary %s not configured\n", version)
 				os.Exit(1)
 			}
 

--- a/cmd/playground/startChain.go
+++ b/cmd/playground/startChain.go
@@ -16,6 +16,9 @@ import (
 )
 
 // startChainCmd represents the startChainCmd
+//
+// TODO: refactor all of the available commands to more layers for easier contextualization.
+// e.g. use `h p chain start` and `h p node info` instead of `h p start-chain` and `h p get-node`
 var startChainCmd = &cobra.Command{
 	Use:   "start-chain [chain_id]",
 	Args:  cobra.ExactArgs(1),

--- a/playground/filesmanager/build_evmos.go
+++ b/playground/filesmanager/build_evmos.go
@@ -33,6 +33,12 @@ func SaveEvmosBuiltVersion(version string) error {
 	return MoveFile(GetBranchFolder(version)+"/build/evmosd", GetEvmosdPath(version))
 }
 
+// TODO: this stuff should be refactored together with SaveEvmosBuiltVersion and ideally served by a shared interface that's reimplemented per chain.
+func SaveSagaOSBuiltVersion(version string) error {
+	_ = CreateBuildsDir()
+	return MoveFile(GetBranchFolder(version)+"/build/sagaosd", GetSagaosdPath(version))
+}
+
 func MoveFile(origin string, destination string) error {
 	return os.Rename(origin, destination)
 }

--- a/playground/filesmanager/git.go
+++ b/playground/filesmanager/git.go
@@ -12,6 +12,11 @@ func GitCloneHermesBranch(version string) error {
 	return GitCloneBranch(version, GetBranchFolder(version), "https://github.com/informalsystems/hermes")
 }
 
+// TODO: refactor here to just use GetBinaryInfo and return the github link.
+func GitCloneSagaOSBranch(version string) error {
+	return GitCloneBranch(version, GetBranchFolder(version), "https://github.com/sagaxyz/sagaos")
+}
+
 func GitCloneBranch(version string, dstFolder string, repoURL string) error {
 	cmd := exec.Command("git", "clone", "--depth", "1", "--branch", version, repoURL, dstFolder)
 	_, err := cmd.Output()

--- a/playground/filesmanager/list_versions.go
+++ b/playground/filesmanager/list_versions.go
@@ -4,6 +4,7 @@ import (
 	"os"
 )
 
+// TODO: rename to make more general
 func GetAllEvmosdVersions() ([]string, error) {
 	files, err := os.Open(GetBuildsDir())
 	if err != nil {

--- a/playground/filesmanager/path.go
+++ b/playground/filesmanager/path.go
@@ -82,6 +82,11 @@ func GetEvmosdPath(version string) string {
 	return GetBuildsDir() + "/evmosd" + version
 }
 
+// TODO: refactor this to all use the same function instead of GetEvmosdPath, GetSagaosdPath, GetDaemondPath, etc.
+func GetSagaosdPath(version string) string {
+	return GetBuildsDir() + "/sagaosd" + version
+}
+
 func GetDaemondPath(binaryName string) string {
 	return GetBuildsDir() + "/" + binaryName
 }

--- a/playground/sagaos/sagaosd.go
+++ b/playground/sagaos/sagaosd.go
@@ -1,0 +1,36 @@
+package sagaos
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hanchon/hanchond/playground/cosmosdaemon"
+	"github.com/hanchon/hanchond/playground/filesmanager"
+)
+
+type SagaOS struct {
+	*cosmosdaemon.Daemon
+}
+
+func NewSagaOS(moniker string, version string, homeDir string, chainID string, keyName string, denom string) *SagaOS {
+	daemonName := version
+	if !strings.Contains(version, "sagaosd") {
+		daemonName = fmt.Sprintf("sagaosd%s", version)
+	}
+	s := &SagaOS{
+		Daemon: cosmosdaemon.NewDameon(
+			moniker,
+			daemonName,
+			homeDir,
+			chainID,
+			keyName,
+			cosmosdaemon.EthAlgo,
+			denom,
+			"saga",
+			cosmosdaemon.EvmosSDK,
+		),
+	}
+	s.SetBinaryPath(filesmanager.GetDaemondPath(daemonName))
+	s.SetCustomConfig(s.UpdateAppFile)
+	return s
+}

--- a/playground/sagaos/start.go
+++ b/playground/sagaos/start.go
@@ -1,0 +1,15 @@
+package sagaos
+
+import "fmt"
+
+// TODO: refactor to be reuse the same method from Evmos?
+func (s *SagaOS) Start() (int, error) {
+	logFile := s.HomeDir + "/run.log"
+	cmd := fmt.Sprintf("%s start --chain-id %s --home %s --json-rpc.api eth,txpool,personal,net,debug,web3 --api.enable --grpc.enable >> %s 2>&1",
+		s.BinaryPath,
+		s.ChainID,
+		s.HomeDir,
+		logFile,
+	)
+	return s.Daemon.Start(cmd)
+}


### PR DESCRIPTION
This PR adds support for building and running sagaxyz/sagaos nodes. Additionally a bunch of the codebase is being refactored as to better support adding more binaries (e.g. SSC or others).

Closes #2 