### PR TITLE
imp(config): Refactor config to support YAML

### DIFF
--- a/cmd/playground/buildEvmos.go
+++ b/cmd/playground/buildEvmos.go
@@ -3,7 +3,6 @@ package playground
 import (
 	"errors"
 
-	"github.com/hanchon/hanchond/playground/evmos"
 	"github.com/spf13/cobra"
 )
 
@@ -19,9 +18,7 @@ var buildEvmosCmd = &cobra.Command{
 		}
 
 		version := args[0]
-		chainInfo := evmos.ChainInfo
-
-		return RunBuildEVMChainCmd(cmd, chainInfo, version)
+		return RunBuildEVMChainCmd(cmd, "evmos", version)
 	},
 }
 

--- a/cmd/playground/buildHermes.go
+++ b/cmd/playground/buildHermes.go
@@ -8,13 +8,13 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const DEFAULT_HERMES_VERSION = "v1.10.5"
+const DefaultHermesVersion = "v1.10.5"
 
 // buildHermesCmd represents the buildHermes command
 var buildHermesCmd = &cobra.Command{
 	Use:   "build-hermes",
 	Short: "Build the Hermes relayer binary",
-	Long:  fmt.Sprintf(`It builds the relayer from source, it accepts a version flag to specify any tag. It defaults to: %s.`, DEFAULT_HERMES_VERSION),
+	Long:  fmt.Sprintf(`It builds the relayer from source, it accepts a version flag to specify any tag. It defaults to: %s.`, DefaultHermesVersion),
 	Run: func(cmd *cobra.Command, _ []string) {
 		// TODO: download from release page instead of building from source
 		_ = filesmanager.SetHomeFolderFromCobraFlags(cmd)
@@ -51,5 +51,5 @@ var buildHermesCmd = &cobra.Command{
 
 func init() {
 	PlaygroundCmd.AddCommand(buildHermesCmd)
-	buildHermesCmd.PersistentFlags().StringP("version", "v", DEFAULT_HERMES_VERSION, "Hermes version to build")
+	buildHermesCmd.PersistentFlags().StringP("version", "v", DefaultHermesVersion, "Hermes version to build")
 }

--- a/cmd/playground/build_saga_os.go
+++ b/cmd/playground/build_saga_os.go
@@ -3,7 +3,6 @@ package playground
 import (
 	"errors"
 
-	"github.com/hanchon/hanchond/playground/sagaos"
 	"github.com/spf13/cobra"
 )
 
@@ -18,9 +17,7 @@ var buildSagaOSCmd = &cobra.Command{
 		}
 
 		version := args[0]
-		chainInfo := sagaos.ChainInfo
-
-		return RunBuildEVMChainCmd(cmd, chainInfo, version)
+		return RunBuildEVMChainCmd(cmd, "sagaos", version)
 	},
 }
 

--- a/cmd/playground/query/tx.go
+++ b/cmd/playground/query/tx.go
@@ -23,6 +23,7 @@ var txCmd = &cobra.Command{
 
 		txhash := args[0]
 
+		// TODO: this should be refactored to check the node in the DB and get the correct client from there to instantiate the correct daemon
 		e := evmos.NewEvmosFromDB(queries, nodeID)
 		resp, err := e.GetTransaction(txhash)
 		if err != nil {

--- a/cmd/playground/startNode.go
+++ b/cmd/playground/startNode.go
@@ -6,85 +6,56 @@ import (
 	"strconv"
 
 	"github.com/hanchon/hanchond/lib/utils"
-	"github.com/hanchon/hanchond/playground/database"
-	"github.com/hanchon/hanchond/playground/evmos"
-	"github.com/hanchon/hanchond/playground/gaia"
-	"github.com/hanchon/hanchond/playground/sagaos"
+	"github.com/hanchon/hanchond/playground/cosmosdaemon"
+	"github.com/hanchon/hanchond/playground/filesmanager"
 	"github.com/hanchon/hanchond/playground/sql"
 	"github.com/spf13/cobra"
 )
 
 // startNodeCmd represents the startNode command
 var startNodeCmd = &cobra.Command{
-	Use:   "start-node [node_id]",
-	Args:  cobra.ExactArgs(1),
-	Short: "Starts a node with the given ID",
-	Long:  `It will run the node in a subprocess, saving the pid in the database in case it needs to be stopped in the future`,
+	// TODO: this should not require the chain ID but just get the node from the DB should contain all info
+	Use:   "start-node [chain_id] [node_id]",
+	Args:  cobra.ExactArgs(2),
+	Short: "Start a node for a specific chain",
+	Long:  `It will start a node for a specific chain. The node will be started with the given chain ID and node ID.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		chainID, err := strconv.ParseInt(args[0], 10, 64)
+		if err != nil {
+			utils.ExitError(fmt.Errorf("invalid chain ID"))
+		}
+
+		nodeID, err := strconv.ParseInt(args[1], 10, 64)
+		if err != nil {
+			utils.ExitError(fmt.Errorf("invalid node ID"))
+		}
+
 		queries := sql.InitDBFromCmd(cmd)
 
-		id := args[0]
-		idNumber, err := strconv.ParseInt(id, 10, 64)
+		chain, err := queries.GetChain(context.Background(), chainID)
 		if err != nil {
-			utils.ExitError(fmt.Errorf("could not parse the ID: %w", err))
+			utils.ExitError(fmt.Errorf("could not get the chain info from db: %w", err))
 		}
 
-		node, err := queries.GetNode(context.Background(), idNumber)
+		chainInfo := chain.MustParseChainInfo()
+		path := filesmanager.GetNodeHomeFolder(chainID, nodeID)
+
+		daemon := cosmosdaemon.NewDameon(
+			chainInfo,
+			fmt.Sprintf("moniker-%d-%d", chainID, nodeID),
+			// TODO: the version here is wrong, this is passing the whole chainInfo as a string
+			chain.ChainInfo,
+			path,
+			chain.ChainID,
+			fmt.Sprintf("validator-key-%d-%d", chainID, nodeID),
+		)
+
+		pid, err := daemon.StartNodeAndStoreInfo(queries, nodeID)
 		if err != nil {
-			utils.ExitError(fmt.Errorf("could not get the node: %w", err))
+			utils.ExitError(fmt.Errorf("error starting node: %w", err))
 		}
 
-		chain, err := queries.GetChain(context.Background(), node.ChainID)
-		if err != nil {
-			utils.ExitError(fmt.Errorf("could not get the chain: %w", err))
-		}
-
-		ci := chain.MustParseChainInfo()
-
-		var pID int
-		switch ci.GetBinaryName() {
-		case evmos.ChainInfo.GetBinaryName():
-			d := evmos.NewEvmos(
-				node.Moniker,
-				node.Version,
-				node.ConfigFolder,
-				chain.ChainID,
-				node.ValidatorKeyName,
-			)
-			pID, err = d.Start()
-		case gaia.ChainInfo.GetBinaryName():
-			d := gaia.NewGaia(
-				node.Moniker,
-				node.ConfigFolder,
-				chain.ChainID,
-				node.ValidatorKeyName,
-			)
-			pID, err = d.Start()
-		case sagaos.ChainInfo.GetBinaryName():
-			d := sagaos.NewSagaOS(
-				node.Moniker,
-				node.Version,
-				node.ConfigFolder,
-				chain.ChainID,
-				node.ValidatorKeyName,
-			)
-			pID, err = d.Start()
-		default:
-			panic("invalid binary name: " + ci.GetBinaryName())
-		}
-		if err != nil {
-			utils.ExitError(fmt.Errorf("could not start the node: %w", err))
-		}
-		utils.Log("Node is running with pID: %d", pID)
-
-		err = queries.SetProcessID(context.Background(), database.SetProcessIDParams{
-			ProcessID: int64(pID),
-			IsRunning: 1,
-			ID:        node.ID,
-		})
-		if err != nil {
-			utils.ExitError(fmt.Errorf("could not save the process ID to the db: %w", err))
-		}
+		utils.Log("Node started successfully with PID: %d", pid)
 	},
 }
 

--- a/cmd/playground/tx/ibcTransfer.go
+++ b/cmd/playground/tx/ibcTransfer.go
@@ -32,6 +32,7 @@ var ibcTransferCmd = &cobra.Command{
 		dstWallet := args[0]
 		amount := args[1]
 
+		// TODO: this should be refactored to check the node in the DB and get the correct client from there to instantiate the correct daemon instead of hardcoding evmos
 		e := evmos.NewEvmosFromDB(queries, nodeID)
 		denom, err := cmd.Flags().GetString("denom")
 		if err != nil {

--- a/playground/config/chain_config.yaml
+++ b/playground/config/chain_config.yaml
@@ -1,0 +1,45 @@
+chains:
+  evmos:
+    account_prefix: "evmos"
+    binary_name: "evmosd"
+    chain_id_base: "evmos_9000-"
+    client_name: "evmos"
+    denom: "aevmos"
+    repo_url: "https://github.com/evmos/evmos"
+    hd_path: "m/44'/60'/0'/0"
+    key_algo: "eth_secp256k1"
+    sdk_version: "evmosSDK"
+    build:
+      make_target: "build"
+      make_options: "COSMOS_BUILD_OPTIONS=nooptimization,nostrip"
+      binary_path: "build/evmosd"
+
+  sagaos:
+    account_prefix: "saga"
+    binary_name: "sagaosd"
+    chain_id_base: "sagaos_1234-"
+    client_name: "sagaos"
+    denom: "saga"
+    repo_url: "https://github.com/sagaxyz/sagaos"
+    hd_path: "m/44'/118'/0'/0"
+    key_algo: "eth_secp256k1"
+    sdk_version: "evmosSDK"
+    build:
+      make_target: "build"
+      make_options: "COSMOS_BUILD_OPTIONS=nooptimization,nostrip"
+      binary_path: "build/sagaosd"
+
+  gaia:
+    account_prefix: "cosmos"
+    binary_name: "gaiad"
+    chain_id_base: "cosmoshub-"
+    client_name: "gaia"
+    denom: "icsstake"
+    repo_url: "https://github.com/cosmos/gaia"
+    hd_path: "m/44'/118'/0'/0"
+    key_algo: "secp256k1"
+    sdk_version: "gaiaSDK"
+    build:
+      make_target: "build"
+      make_options: "COSMOS_BUILD_OPTIONS=nooptimization,nostrip"
+      binary_path: "build/gaiad" 

--- a/playground/config/config.go
+++ b/playground/config/config.go
@@ -1,0 +1,85 @@
+package config
+
+import (
+	_ "embed"
+	"fmt"
+
+	"github.com/hanchon/hanchond/playground/types"
+	"gopkg.in/yaml.v3"
+)
+
+//go:embed chain_config.yaml
+var configData []byte
+
+type BuildConfig struct {
+	MakeTarget  string `yaml:"make_target"`
+	MakeOptions string `yaml:"make_options"`
+	BinaryPath  string `yaml:"binary_path"`
+}
+
+// TODO: check if all of the fields are being used. If not there is probably some refactoring necessary to use that. E.g. use the `make` target and options to build the binary instead of hardcoding them.
+type ChainConfig struct {
+	AccountPrefix string      `yaml:"account_prefix"`
+	BinaryName    string      `yaml:"binary_name"`
+	ChainIDBase   string      `yaml:"chain_id_base"`
+	ClientName    string      `yaml:"client_name"`
+	Denom         string      `yaml:"denom"`
+	RepoURL       string      `yaml:"repo_url"`
+	HDPath        string      `yaml:"hd_path"`
+	KeyAlgo       string      `yaml:"key_algo"`
+	SDKVersion    string      `yaml:"sdk_version"`
+	Build         BuildConfig `yaml:"build"`
+}
+
+type Config struct {
+	Chains map[string]ChainConfig `yaml:"chains"`
+}
+
+var config *Config
+
+func init() {
+	if err := loadConfig(); err != nil {
+		panic(fmt.Sprintf("failed to load config: %v", err))
+	}
+}
+
+// loadConfig loads the chain configuration from the embedded YAML file
+func loadConfig() error {
+	config = &Config{}
+	if err := yaml.Unmarshal(configData, config); err != nil {
+		return fmt.Errorf("error parsing config file: %w", err)
+	}
+	return nil
+}
+
+// GetChainConfig returns the configuration for a specific chain
+//
+// TODO: this should actually not be the chain name aka chain ID but rather the client's name.
+// e.g. for evmos it should be "evmos" instead of "evmos_9001-1" or "evmosd"
+func GetChainConfig(chainName string) (*ChainConfig, error) {
+	if config == nil {
+		return nil, fmt.Errorf("config not loaded")
+	}
+
+	chainConfig, exists := config.Chains[chainName]
+	if !exists {
+		return nil, fmt.Errorf("chain %s not found in configuration", chainName)
+	}
+
+	return &chainConfig, nil
+}
+
+// ToChainInfo converts a ChainConfig to a types.ChainInfo
+func (c *ChainConfig) ToChainInfo() types.ChainInfo {
+	return types.NewChainInfo(
+		c.AccountPrefix,
+		c.BinaryName,
+		c.ChainIDBase,
+		c.ClientName,
+		c.Denom,
+		c.RepoURL,
+		types.HDPath(c.HDPath),
+		types.SignatureAlgo(c.KeyAlgo),
+		types.SDKVersion(c.SDKVersion),
+	)
+}

--- a/playground/evmos/command.go
+++ b/playground/evmos/command.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 )
 
+// TODO: this should be refactored to the default Cosmos daemon
 func (e *Evmos) Start() (int, error) {
 	logFile := e.HomeDir + "/run.log"
 	cmd := fmt.Sprintf("%s start --chain-id %s --home %s --json-rpc.api eth,txpool,personal,net,debug,web3 --json-rpc.enable --api.enable --grpc.enable >> %s 2>&1",

--- a/playground/evmos/command_bank.go
+++ b/playground/evmos/command_bank.go
@@ -5,6 +5,7 @@ import (
 	"os/exec"
 )
 
+// TODO: this should be refactored to the default Cosmos daemon
 func (e *Evmos) CheckBalance(wallet string) (string, error) {
 	command := exec.Command( //nolint:gosec
 		e.GetVersionedBinaryPath(),

--- a/playground/evmos/command_gov.go
+++ b/playground/evmos/command_gov.go
@@ -20,6 +20,7 @@ type STRv1 struct {
 	Symbol   string
 }
 
+// TODO: this only works for evmos < v19 or something so this should be reflected in the error message -- low prio
 func (e *Evmos) CreateSTRv1Proposal(params STRv1) (string, error) {
 	metadata := fmt.Sprintf(`
 {

--- a/playground/evmos/command_ibc.go
+++ b/playground/evmos/command_ibc.go
@@ -5,6 +5,7 @@ import (
 	"os/exec"
 )
 
+// TODO: this can be refactored to the default Cosmos daemon as we assume all chains are IBC-enabled for now
 func (e *Evmos) SendIBC(port, channel, receiver, amount string) (string, error) {
 	command := exec.Command( //nolint:gosec
 		e.GetVersionedBinaryPath(),

--- a/playground/evmos/command_tx.go
+++ b/playground/evmos/command_tx.go
@@ -5,6 +5,7 @@ import (
 	"os/exec"
 )
 
+// TODO: this can probably be refactored for all chains and use the chain config / chain info
 func (e *Evmos) GetTransaction(txhash string) (string, error) {
 	command := exec.Command( //nolint:gosec
 		e.GetVersionedBinaryPath(),

--- a/playground/evmos/config_files.go
+++ b/playground/evmos/config_files.go
@@ -14,6 +14,7 @@ func (e *Evmos) UpdateAppFile() error {
 	return e.Daemon.SaveAppFile(appFile)
 }
 
+// TODO: this isn't really required, we can just set this using the additional start flags in the chain config
 func (e *Evmos) enableWeb3API(config []byte) []byte {
 	configValues := string(config)
 	configValues = strings.Replace(

--- a/playground/evmos/db.go
+++ b/playground/evmos/db.go
@@ -14,6 +14,7 @@ type NodeFromDB struct {
 	Ports database.Port
 }
 
+// TODO: this can be moved to the cosmosdaemon package
 func GetNodeFromDB(queries *database.Queries, nodeID string) *NodeFromDB {
 	validatorID, err := strconv.ParseInt(nodeID, 10, 64)
 	if err != nil {
@@ -40,6 +41,7 @@ func GetNodeFromDB(queries *database.Queries, nodeID string) *NodeFromDB {
 	}
 }
 
+// TODO: this shouldn't be required anymore after fully refactoring to use the chain config
 func NewEvmosFromDB(queries *database.Queries, nodeID string) *Evmos {
 	data := GetNodeFromDB(queries, nodeID)
 	e := NewEvmos(data.Node.Moniker, data.Node.Version, data.Node.ConfigFolder, data.Chain.ChainID, data.Node.ValidatorKeyName)

--- a/playground/evmos/evmosd.go
+++ b/playground/evmos/evmosd.go
@@ -21,6 +21,7 @@ type Evmos struct {
 	*cosmosdaemon.Daemon
 }
 
+// TODO: this should be able to be removed after fully refactoring to use the chain config
 func NewEvmos(moniker, version, homeDir, chainID, keyName string) *Evmos {
 	e := &Evmos{
 		Daemon: cosmosdaemon.NewDameon(

--- a/playground/filesmanager/build_evmos.go
+++ b/playground/filesmanager/build_evmos.go
@@ -16,6 +16,7 @@ func BuildEVMChainVersion(version string) error {
 	return BuildEVMBinary(GetBranchFolder(version))
 }
 
+// TODO: this should also use the chain config that specifies the build command and options for the corresponding repository
 func BuildEVMBinary(path string) error {
 	if err := os.Chdir(path); err != nil {
 		return err


### PR DESCRIPTION
I'm thinking of simplifying the configuration here to support using a YAML configuration file to specify the different supported chains.
This requires refactors throughout the whole codebase, which could save a lot of boilerplate code and make it much easier to add new node binaries.

----

currently WIP / not sure I'll actually implement it though or if the existing approach is ok.