### PR TITLE
fix: refactor adding IBC channel with Hermes for Cosmos chains

### DIFF
--- a/cmd/playground/hermesAddChannel.go
+++ b/cmd/playground/hermesAddChannel.go
@@ -9,10 +9,7 @@ import (
 
 	"github.com/hanchon/hanchond/lib/utils"
 	"github.com/hanchon/hanchond/playground/database"
-	"github.com/hanchon/hanchond/playground/evmos"
-	"github.com/hanchon/hanchond/playground/gaia"
 	"github.com/hanchon/hanchond/playground/hermes"
-	"github.com/hanchon/hanchond/playground/sagaos"
 	"github.com/hanchon/hanchond/playground/sql"
 )
 
@@ -66,39 +63,19 @@ var hermesAddChannelCmd = &cobra.Command{
 			chainInfo := v.MustParseChainInfo()
 			binaryName := chainInfo.GetBinaryName()
 
-			switch binaryName {
-			case gaia.ChainInfo.GetBinaryName():
-				utils.Log("Adding %s chain", binaryName)
-				if err := h.AddCosmosChain(
-					chainInfo,
-					v.ChainID_2,
-					hermes.LocalEndpoint(v.P26657),
-					hermes.LocalEndpoint(v.P9090),
-					v.ValidatorKeyName,
-					v.ValidatorKey,
-				); err != nil {
-					utils.ExitError(
-						fmt.Errorf("error adding chain %d to the relayer: %s", i, err.Error()),
-					)
-				}
-			case evmos.ChainInfo.GetBinaryName(), sagaos.ChainInfo.GetBinaryName():
-				utils.Log("Adding chain %d: %s", i, binaryName)
-				if err := h.AddEVMChain(
-					chainInfo,
-					v.ChainID_2,
-					hermes.LocalEndpoint(v.P26657),
-					hermes.LocalEndpoint(v.P9090),
-					v.ValidatorKeyName,
-					v.ValidatorKey,
-				); err != nil {
-					utils.ExitError(
-						fmt.Errorf("error adding chain %d to the relayer: %s", i, err.Error()),
-					)
-				}
-			default:
-				utils.ExitError(fmt.Errorf("incorrect binary name: %s", binaryName))
+			utils.Log("Adding chain %d: %s", i, binaryName)
+			if err := h.AddChain(
+				chainInfo,
+				v.ChainID_2,
+				hermes.LocalEndpoint(v.P26657),
+				hermes.LocalEndpoint(v.P9090),
+				v.ValidatorKeyName,
+				v.ValidatorKey,
+			); err != nil {
+				utils.ExitError(
+					fmt.Errorf("error adding chain %d to the relayer: %s", i, err.Error()),
+				)
 			}
-
 		}
 
 		utils.Log("Calling create channel")

--- a/cmd/playground/relayer/addChainConfig.go
+++ b/cmd/playground/relayer/addChainConfig.go
@@ -65,10 +65,12 @@ var addChainConfigCmd = &cobra.Command{
 		}
 
 		hdPath := types.CosmosHDPath
+		algo := types.CosmosAlgo
 		if isEvm {
 			// TODO: maybe check here if that's the right hd path to use? could e.g. get user
 			// confirmation
 			hdPath = types.EthHDPath
+			algo = types.EthAlgo
 		}
 
 		defaultChainInfo := types.NewChainInfo(
@@ -79,37 +81,18 @@ var addChainConfigCmd = &cobra.Command{
 			denom,
 			"external",
 			hdPath,
-			types.CosmosAlgo,
+			algo,
 		)
 
-		switch isEvm {
-		case false:
-			utils.Log("adding a non-EVM chain")
-			if err := h.AddCosmosChain(
-				defaultChainInfo,
-				chainID,
-				p26657,
-				p9090,
-				keyname,
-				keymnemonic,
-			); err != nil {
-				utils.ExitError(fmt.Errorf("error adding first chain to the relayer: %w", err))
-			}
-		case true:
-			chainInfo := defaultChainInfo
-			chainInfo.KeyAlgo = types.EthAlgo
-
-			utils.Log("adding a EVM chain")
-			if err := h.AddEVMChain(
-				chainInfo,
-				chainID,
-				p26657,
-				p9090,
-				keyname,
-				keymnemonic,
-			); err != nil {
-				utils.ExitError(fmt.Errorf("error adding first chain to the relayer: %w", err))
-			}
+		if err := h.AddChain(
+			defaultChainInfo,
+			chainID,
+			p26657,
+			p9090,
+			keyname,
+			keymnemonic,
+		); err != nil {
+			utils.ExitError(fmt.Errorf("error adding first chain to the relayer: %w", err))
 		}
 	},
 }


### PR DESCRIPTION
This PR unifies the way that the IBC channels are created with Hermes, where before there was a problem for Cosmos chains that did not have the relayer key set up prior to testing.