### PR TITLE
feat: add support to pass memos in IBC transfer

### DIFF
--- a/cmd/playground/tx/ibcTransfer.go
+++ b/cmd/playground/tx/ibcTransfer.go
@@ -58,7 +58,12 @@ var ibcTransferCmd = &cobra.Command{
 			utils.ExitError(fmt.Errorf("could not get the for node: %w", err))
 		}
 
-		out, err := d.SendIBC("transfer", channel, dstWallet, sentFunds)
+		memo, err := cmd.Flags().GetString("memo")
+		if err != nil {
+			utils.ExitError(fmt.Errorf("could not get the memo: %w", err))
+		}
+
+		out, err := d.SendIBC("transfer", channel, dstWallet, sentFunds, memo)
 		if err != nil {
 			utils.ExitError(fmt.Errorf("error sending the transaction: %w", err))
 		}
@@ -79,4 +84,5 @@ var ibcTransferCmd = &cobra.Command{
 func init() {
 	TxCmd.AddCommand(ibcTransferCmd)
 	ibcTransferCmd.Flags().StringP("channel", "c", "channel-0", "IBC channel")
+	ibcTransferCmd.Flags().StringP("memo", "m", "", "Optional field to pass an IBC memo along with the transfer")
 }

--- a/playground/cosmosdaemon/commands.go
+++ b/playground/cosmosdaemon/commands.go
@@ -165,9 +165,8 @@ func (d *Daemon) Start(startCmd string) (int, error) {
 
 // SendIBC send a simple IBC transfer using the CLI.
 //
-// TODO: implement custom memos.
 // TODO: simulate maybe? to avoid hardcoding fees.
-func (d *Daemon) SendIBC(port, channel, recipient string, amount types.Coin) (string, error) {
+func (d *Daemon) SendIBC(port, channel, recipient string, amount types.Coin, memo string) (string, error) {
 	feeAmount := 1000
 	// if the base denom is an atto unit, use a higher amount of fees to send with the transaction.
 	if strings.HasPrefix(d.BaseDenom, "a") {
@@ -178,8 +177,7 @@ func (d *Daemon) SendIBC(port, channel, recipient string, amount types.Coin) (st
 		return "", errors.New("ports are not set")
 	}
 
-	command := exec.Command( //nolint:gosec
-		d.GetVersionedBinaryPath(),
+	commandSlice := []string{
 		"tx",
 		"ibc-transfer",
 		"transfer",
@@ -200,6 +198,15 @@ func (d *Daemon) SendIBC(port, channel, recipient string, amount types.Coin) (st
 		"--fees",
 		fmt.Sprintf("%d%s", feeAmount, d.BaseDenom),
 		"-y",
+	}
+
+	if memo != "" {
+		commandSlice = append(commandSlice, "--memo", memo)
+	}
+
+	command := exec.Command( //nolint:gosec
+		d.GetVersionedBinaryPath(),
+		commandSlice...,
 	)
 
 	out, err := command.CombinedOutput()

--- a/playground/cosmosdaemon/daemon.go
+++ b/playground/cosmosdaemon/daemon.go
@@ -14,7 +14,7 @@ import (
 // that are configured in this tool should fulfill.
 type IDaemon interface {
 	Start() (pid int, err error)
-	SendIBC(port, channel, recipient string, amount types.Coin) (string, error)
+	SendIBC(port, channel, recipient string, amount types.Coin, memo string) (string, error)
 }
 
 type Daemon struct {


### PR DESCRIPTION
This PR adds support for custom memos to be passed along with the `hanchond tx ibc-transfer` command by passing the `--memo` flag.