### PR TITLE
feat: add version subcommand

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,17 @@
 .phony: build format install docs-dev docs-build generate generate-explorer lint
 
+export VERSION := $(shell echo $(shell git describe --tags --always --match "v*") | sed 's/^v//')
+
+ld_flags = -X github.com/hanchon/hanchond/cmd.Version=$(VERSION)
+
 build:
-	@nix develop -c go build -o build/
+	@nix develop -c go build -o build/ -ldflags '$(ld_flags)'
 
 format:
 	@nix develop -c golangci-lint fmt -c .golangci.yml
 
 install:
-	@nix develop -c go install
+	@nix develop -c go install -ldflags '$(ld_flags)'
 
 docs-dev:
 	@bun i && bun run docs:dev

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -25,6 +25,7 @@ func Execute() {
 
 func init() {
 	rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+	rootCmd.AddCommand(VersionCmd)
 	rootCmd.AddCommand(convert.ConvertCmd)
 	rootCmd.AddCommand(playground.PlaygroundCmd)
 	rootCmd.AddCommand(repo.RepoCmd)

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,18 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var Version = ""
+
+var VersionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Show the tool version.",
+	Args:  cobra.ExactArgs(0),
+	Run: func(_ *cobra.Command, args []string) {
+		fmt.Println(Version)
+	},
+}


### PR DESCRIPTION
This PR adds the `hanchond version` subcommand to include the currently used version of the tool.
